### PR TITLE
Describe spire-tutorials contents more accurately

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
-# spire-tutorials
+# SPIRE Tutorials
 
-Example files referenced by the tutorials at https://spiffe.io
+The tutorials in this repo describe how to install SPIRE and integrate it with software typically used with SPIRE. All of the current tutorials work only on Kubernetes. The following tutorials are available:
+
+* [SPIRE quickstart](https://spiffe.io/spire/try/getting-started-k8s/)
+* [Authenticating to AWS using OIDC ](https://spiffe.io/spire/try/oidc-federation-aws/)
+* [Integrating with Envoy using X.509 certs](k8s/envoy-x509)
+* [Integrating with Envoy using JWT](k8s/envoy-jwt)
+
+Additional examples of how to install and deploy SPIRE are available. The [SPIRE](https://spiffe.io/spire/try/) website includes a [Linux/Mac quickstart guide](https://spiffe.io/spire/try/getting-started-linux-macos-x/) and [SPIFFE library](https://spiffe.io/spire/try/spiffe-library-usage-examples/) usage examples. The [SPIRE examples](../spire-examples) repo on GitHub includes more usage examples for Kubernetes deployments, Postgres integration, and a Docker-based Envoy example.
+
+For general information about SPIRE and the [SPIFFE](../spiffe) zero-trust authentication spec that SPIRE implements, see the SPIRE [GitHub repo](../spire) and [website](https://spiffe.io).

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 The tutorials in this repo describe how to install SPIRE and integrate it with software typically used with SPIRE. All of the current tutorials work only on Kubernetes. The following tutorials are available:
 
-* [SPIRE quickstart](https://spiffe.io/spire/try/getting-started-k8s/)
-* [Authenticating to AWS using OIDC ](https://spiffe.io/spire/try/oidc-federation-aws/)
+* [Quickstart for Kubernetes](https://spiffe.io/spire/try/getting-started-k8s/)
+* [AWS OIDC Authentication](https://spiffe.io/spire/try/oidc-federation-aws/)
 * [Integrating with Envoy using X.509 certs](k8s/envoy-x509)
 * [Integrating with Envoy using JWT](k8s/envoy-jwt)
 
-Additional examples of how to install and deploy SPIRE are available. The [SPIRE](https://spiffe.io/spire/try/) website includes a [Linux/Mac quickstart guide](https://spiffe.io/spire/try/getting-started-linux-macos-x/) and [SPIFFE library](https://spiffe.io/spire/try/spiffe-library-usage-examples/) usage examples. The [SPIRE examples](../spire-examples) repo on GitHub includes more usage examples for Kubernetes deployments, Postgres integration, and a Docker-based Envoy example.
+Additional examples of how to install and deploy SPIRE are available. The spiffe.io [Try SPIRE](https://spiffe.io/spire/try/) page includes a [Quickstart for Linux and MacOS X](https://spiffe.io/spire/try/getting-started-linux-macos-x/) and [SPIFFE Library Usage Examples](https://spiffe.io/spire/try/spiffe-library-usage-examples/). The [SPIRE Examples](https://github.com/spiffe/spire-examples) repo on GitHub includes more usage examples for Kubernetes deployments, including Postgres integration, and a Docker-based Envoy example.
 
-For general information about SPIRE and the [SPIFFE](../spiffe) zero-trust authentication spec that SPIRE implements, see the SPIRE [GitHub repo](../spire) and [website](https://spiffe.io).
+For general information about SPIRE and the [SPIFFE](https://github.com/spiffe/spiffe) zero-trust authentication spec that SPIRE implements, see the SPIRE [GitHub repo](https://github.com/spiffe/spire) and [spiffe.io website](https://spiffe.io).


### PR DESCRIPTION
The current README says that the tutorial documentation is on
spiffe.io. That's no longer 100% true. There are plans afoot to copy
the SPIRE docs from GitHub to spiffe.io. This PR is an interim change
until that comes to pass.

[Since my draft version of this PR, I fixed the broken links noted by Dave and made additional minor edits, such as changing the capitalization used in the links.]

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>