### PR TITLE
replaced verify_subject_alt_name by match_subject_alt_names

### DIFF
--- a/k8s/envoy-jwt/k8s/backend/config/envoy.yaml
+++ b/k8s/envoy-jwt/k8s/backend/config/envoy.yaml
@@ -52,9 +52,9 @@ static_resources:
           combined_validation_context:
             # validate the SPIFFE ID of incoming clients (optionally)
             default_validation_context:
-              verify_subject_alt_name:
-                - "spiffe://example.org/ns/default/sa/default/frontend"
-                - "spiffe://example.org/ns/default/sa/default/frontend-2"
+              match_subject_alt_names:
+                - exact: "spiffe://example.org/ns/default/sa/default/frontend"
+                - exact: "spiffe://example.org/ns/default/sa/default/frontend-2"
             # obtain the trust bundle from SDS
             validation_context_sds_secret_config:
               name: "spiffe://example.org"

--- a/k8s/envoy-jwt/k8s/frontend-2/config/envoy.yaml
+++ b/k8s/envoy-jwt/k8s/frontend-2/config/envoy.yaml
@@ -82,8 +82,8 @@ static_resources:
         combined_validation_context:
           # validate the SPIFFE ID of the server (recommended)
           default_validation_context:
-            verify_subject_alt_name:
-              - "spiffe://example.org/ns/default/sa/default/backend"
+            match_subject_alt_names:
+              - exact: "spiffe://example.org/ns/default/sa/default/backend"
           validation_context_sds_secret_config:
             name: "spiffe://example.org"
             sds_config:

--- a/k8s/envoy-jwt/k8s/frontend/config/envoy.yaml
+++ b/k8s/envoy-jwt/k8s/frontend/config/envoy.yaml
@@ -82,8 +82,8 @@ static_resources:
         combined_validation_context:
           # validate the SPIFFE ID of the server (recommended)
           default_validation_context:
-            verify_subject_alt_name:
-              - "spiffe://example.org/ns/default/sa/default/backend"
+            match_subject_alt_names:
+              - exact: "spiffe://example.org/ns/default/sa/default/backend"
           validation_context_sds_secret_config:
             name: "spiffe://example.org"
             sds_config:


### PR DESCRIPTION
Replacement of `verify_subject_alt_name` (deprecated in new versions of Envoy) by `match_subject_alt_names`

Signed-off-by: Andres Gomez Coronel <andresgomezcoronel@gmail.com>