### PR TITLE
Add link to new nested SPIRE tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # SPIRE Tutorials
 
-The tutorials in this repo describe how to install SPIRE and integrate it with software typically used with SPIRE. All of the current tutorials work only on Kubernetes. The following tutorials are available:
+The tutorials in this repo describe how to install SPIRE and integrate it with software typically used with SPIRE. The following tutorials are available:
 
-* [Quickstart for Kubernetes](https://spiffe.io/spire/try/getting-started-k8s/)
-* [AWS OIDC Authentication](https://spiffe.io/spire/try/oidc-federation-aws/)
-* [Integrating with Envoy using X.509 certs](k8s/envoy-x509)
-* [Integrating with Envoy using JWT](k8s/envoy-jwt)
+| Tutorial | Platform |
+| --- | --- |
+| [Quickstart for Kubernetes](https://spiffe.io/spire/try/getting-started-k8s/) | Kubernetes |
+| [AWS OIDC Authentication](https://spiffe.io/spire/try/oidc-federation-aws/) | Kubernetes |
+| [Integrating with Envoy using X.509 certs](k8s/envoy-x509) | Kubernetes |
+| [Integrating with Envoy using JWT](k8s/envoy-jwt) | Kubernetes |
+| [Nested SPIRE](nested-spire) | Docker Compose |
 
 Additional examples of how to install and deploy SPIRE are available. The spiffe.io [Try SPIRE](https://spiffe.io/spire/try/) page includes a [Quickstart for Linux and MacOS X](https://spiffe.io/spire/try/getting-started-linux-macos-x/) and [SPIFFE Library Usage Examples](https://spiffe.io/spire/try/spiffe-library-usage-examples/). The [SPIRE Examples](https://github.com/spiffe/spire-examples) repo on GitHub includes more usage examples for Kubernetes deployments, including Postgres integration, and a Docker-based Envoy example.
 


### PR DESCRIPTION
I also changed the bullet list of tutorials to a table so the platform
type can be specified (currently Kubernetes or Docker Compose). The
nested SPIRE tutorial is the first non-Kubernetes tutorial in
spire-tutorials.

Signed-off-by: Steve Anderson <steve.anderson@hpe.com>