### PR TITLE
Server image pointed to older version

### DIFF
--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.9.3
+          image: gcr.io/spiffe-io/spire-server:0.10.0
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
The spire server image pointed to old version which had different sql lite schema and pod going to crash back loop

Signed-off-by: Mateti, Vijay <vijaymateti@gmail.com>>