### PR TITLE
Add readiness probe to k8s config of SPIRE server present in quickstart guide

### DIFF
--- a/k8s/oidc-aws/agent-daemonset.yaml
+++ b/k8s/oidc-aws/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.9.3
+          image: gcr.io/spiffe-io/spire-agent:0.11.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/k8s/oidc-aws/agent-daemonset.yaml
+++ b/k8s/oidc-aws/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.11.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -29,8 +29,7 @@ data:
       # TODO: Replace MY_DISCOVERY_DOMAIN with the FQDN of the Discovery Provider that you will configure in DNS
       jwt_issuer = "https://MY_DISCOVERY_DOMAIN"
 
-      upstream_bundle = true
-      svid_ttl = "1h"
+      default_svid_ttl = "1h"
       ca_subject = {
         country = ["US"],
         organization = ["SPIFFE"],

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.9.3
+          image: gcr.io/spiffe-io/spire-server:0.11.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -44,8 +44,13 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock", "--shallow"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.9.3
+          image: gcr.io/spiffe-io/oidc-discovery-provider:0.11.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.11.0
+          image: gcr.io/spiffe-io/spire-server:0.12.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -50,7 +50,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.11.0
+          image: gcr.io/spiffe-io/oidc-discovery-provider:0.12.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.10.0
+          image: gcr.io/spiffe-io/spire-server:0.11.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -44,8 +44,13 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock", "--shallow"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.10.0
+          image: gcr.io/spiffe-io/oidc-discovery-provider:0.11.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.11.0
+          image: gcr.io/spiffe-io/spire-server:0.12.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -50,7 +50,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.11.0
+          image: gcr.io/spiffe-io/oidc-discovery-provider:0.12.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/quickstart/agent-daemonset.yaml
+++ b/k8s/quickstart/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.11.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/k8s/quickstart/client-deployment.yaml
+++ b/k8s/quickstart/client-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: client
-          image: gcr.io/spiffe-io/spire-agent:0.11.0
+          image: gcr.io/spiffe-io/spire-agent:0.12.0
           command: ["sleep"]
           args: ["1000000000"]
           volumeMounts:

--- a/k8s/quickstart/client-deployment.yaml
+++ b/k8s/quickstart/client-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: client
-          image: gcr.io/spiffe-io/spire-agent:0.10.0
+          image: gcr.io/spiffe-io/spire-agent:0.11.0
           command: ["sleep"]
           args: ["1000000000"]
           volumeMounts:

--- a/k8s/quickstart/server-statefulset.yaml
+++ b/k8s/quickstart/server-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.11.0
+          image: gcr.io/spiffe-io/spire-server:0.12.0
           args:
             - -config
             - /run/spire/config/server.conf

--- a/k8s/quickstart/server-statefulset.yaml
+++ b/k8s/quickstart/server-statefulset.yaml
@@ -42,6 +42,14 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            exec:
+              command:
+                - /opt/spire/bin/spire-server
+                - healthcheck
+                - --shallow
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:


### PR DESCRIPTION
- Add _readinessProbe_ to prevent SPIRE server pod from transitioning into _Ready_ status while socket isn't operational yet
- Upgrade SPIRE to 0.11.0 

Solves #35