### PR TITLE
Updates Minikube start command to use --driver option instead of the deprecated --vm-driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - curl -s -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
   # Download minikube.
   - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --bootstrapper=kubeadm
+  - sudo minikube start --driver=none --bootstrapper=kubeadm
   # Fix the kubectl context, as it's often stale.
   - sudo chown -R $USER.$USER ~/.kube
   - sudo chown -R $USER.$USER ~/.minikube


### PR DESCRIPTION
The `--vm-driver` argument has been deprecated in favor of the `--driver` argument. Updating `.travis.yml` to reference the latest argument name.
ref: https://minikube.sigs.k8s.io/docs/commands/start/#options