### PR TITLE
Use the healthcheck endpoints in the kubernetes manifests

### DIFF
--- a/k8s/oidc-aws/agent-daemonset.yaml
+++ b/k8s/oidc-aws/agent-daemonset.yaml
@@ -40,16 +40,19 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-agent
-                - healthcheck
-                - -socketPath
-                - /run/spire/sockets/agent.sock
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -15,13 +15,13 @@ data:
       experimental {
         // Turns on the bundle endpoint (required, true)
         bundle_endpoint_enabled = true
- 
+
         // The address to listen on (optional, defaults to 0.0.0.0)
         // bundle_endpoint_address = "0.0.0.0"
- 
+
         // The port to listen on (optional, defaults to 443)
         bundle_endpoint_port = 8443
-      } 
+      }
       #AWS requires the use of RSA.  EC cryptography is not supported
       ca_key_type = "rsa-2048"
 
@@ -71,4 +71,12 @@ data:
         plugin_data {
         }
       }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
     }

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -38,15 +38,17 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc

--- a/k8s/oidc-vault/k8s/server-configmap.yaml
+++ b/k8s/oidc-vault/k8s/server-configmap.yaml
@@ -15,13 +15,13 @@ data:
       experimental {
         // Turns on the bundle endpoint (required, true)
         bundle_endpoint_enabled = true
- 
+
         // The address to listen on (optional, defaults to 0.0.0.0)
         // bundle_endpoint_address = "0.0.0.0"
- 
+
         // The port to listen on (optional, defaults to 443)
         bundle_endpoint_port = 8443
-      } 
+      }
       ca_key_type = "rsa-2048"
 
       # Creates the iss claim in JWT-SVIDs.
@@ -70,4 +70,12 @@ data:
         plugin_data {
         }
       }
+    }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
     }

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -38,15 +38,17 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock"]
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command: ["/opt/spire/bin/spire-server", "healthcheck", "-registrationUDSPath", "/run/spire/sockets/registration.sock", "--shallow"]
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc

--- a/k8s/quickstart/agent-configmap.yaml
+++ b/k8s/quickstart/agent-configmap.yaml
@@ -42,3 +42,11 @@ data:
           }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/k8s/quickstart/agent-daemonset.yaml
+++ b/k8s/quickstart/agent-daemonset.yaml
@@ -40,16 +40,19 @@ spec:
               mountPath: /run/spire/sockets
               readOnly: false
           livenessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-agent
-                - healthcheck
-                - -socketPath
-                - /run/spire/sockets/agent.sock
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/k8s/quickstart/server-configmap.yaml
+++ b/k8s/quickstart/server-configmap.yaml
@@ -58,3 +58,11 @@ data:
         }
       }
     }
+
+    health_checks {
+      listener_enabled = true
+      bind_address = "0.0.0.0"
+      bind_port = "8080"
+      live_path = "/live"
+      ready_path = "/ready"
+    }

--- a/k8s/quickstart/server-statefulset.yaml
+++ b/k8s/quickstart/server-statefulset.yaml
@@ -34,20 +34,17 @@ spec:
               mountPath: /run/spire/data
               readOnly: false
           livenessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-server
-                - healthcheck
+            httpGet:
+              path: /live
+              port: 8080
             failureThreshold: 2
             initialDelaySeconds: 15
             periodSeconds: 60
             timeoutSeconds: 3
           readinessProbe:
-            exec:
-              command:
-                - /opt/spire/bin/spire-server
-                - healthcheck
-                - --shallow
+            httpGet:
+              path: /ready
+              port: 8080
             initialDelaySeconds: 5
             periodSeconds: 5
       volumes:


### PR DESCRIPTION
Signed-off-by: Ryuma Yoshida <ryuma.y1117@gmail.com>

In the [spiffe/spire](https://github.com/spiffe/spire) repository, the healthcheck endpoints is used for livenessProbe and readinessProbe in the kubernetes manifest. So it would be good to use the endpoints in this repository as well.