### PR TITLE
federation: Disable CGO when building examples

### DIFF
--- a/docker-compose/federation/build.sh
+++ b/docker-compose/federation/build.sh
@@ -4,7 +4,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-(cd src/broker-webapp && GOOS=linux go build -v -o $DIR/docker/broker-webapp/broker-webapp)
-(cd src/stock-quotes-service && GOOS=linux go build -v -o $DIR/docker/stock-quotes-service/stock-quotes-service)
+(cd src/broker-webapp && CGO_ENABLED=0 GOOS=linux go build -v -o $DIR/docker/broker-webapp/broker-webapp)
+(cd src/stock-quotes-service && CGO_ENABLED=0 GOOS=linux go build -v -o $DIR/docker/stock-quotes-service/stock-quotes-service)
 
 docker-compose -f docker-compose.yml build


### PR DESCRIPTION
The two examples fail to start in the containers because they are
compiled with CGO enabled requiring some dynamic standard libraries
that are not present there:

```
$ docker-compose up
...
broker-webapp_1         | /bin/sh: broker-webapp: not found
stock-quotes-service_1  | /bin/sh: stock-quotes-service: not found
...
```

This commit solves that by using CGO_ENABLED=0 to disable CGO.

---

I saw that problem using `go version go1.15.5 linux/amd64`.