### PR TITLE
Update tutorials to use SPIRE 1.0.0

### DIFF
--- a/docker-compose/federation/README.md
+++ b/docker-compose/federation/README.md
@@ -16,9 +16,9 @@ In this tutorial you will learn how to:
 
 The baseline components for SPIFFE federation are:
 
-* Two SPIRE Server instances
-* Two SPIRE Agents, one connected to one SPIRE Server, and the second connected to the other SPIRE Server
-* Two workloads that needs to communicate each other via mTLS, and use the Workload API to get SVIDs and trust bundles
+* Two SPIRE Server instances running version 1.0.0.
+* Two SPIRE Agents running version 1.0.0. One connected to one SPIRE Server, and the second connected to the other SPIRE Server.
+* Two workloads that need to communicate each other via mTLS, and use the Workload API to get SVIDs and trust bundles.
 
 # Scenario
 
@@ -261,7 +261,7 @@ Similarly, once this registration entry is created, when the quotes service asks
 
 That is about it. Now all the pieces are in place to make federation work and demonstrate how the webapp is able to communicate with the quotes service despite having identities with different trust domains.
 
-# Federation Example Using SPIFFE Authentication with SPIRE 1.0.0
+# Federation Example Using SPIFFE Authentication
 
 This section explains how to use Docker Compose to try an example implementation of the SPIFFE auth scenario described in this tutorial.
 

--- a/docker-compose/federation/README.md
+++ b/docker-compose/federation/README.md
@@ -82,7 +82,7 @@ At this point, both SPIRE Servers have exposed their federation endpoints to pro
 
 ## Configure a Federation Endpoint Using Web PKI Authentication
 
-We are going to assume that only the broker's SPIRE Server will use Web PKI authentication for its federation endpoint. The stock market SPIRE Server will still use SPIFFE authentication. Hence, the stock market SPIRE Server configuration remains the same as seen in the previous section.
+We are going to assume that only the broker's SPIRE Server will use Web PKI authentication for its federation endpoint. The stock market SPIRE Server will still use SPIFFE Authentication. Hence, the stock market SPIRE Server configuration remains the same as seen in the previous section.
 
 Then, to configure the broker's SPIRE Server bundle endpoint, we configure the `federation` section as follows:
 
@@ -113,9 +113,9 @@ For SPIFFE Federation using Web PKI to work, you must own the DNS domain specifi
 
 # Configure SPIRE Servers to Retrieve Trust Bundles From Each Other
 
-After configuring federation endpoints, the next step to enable SPIFFE federation is to configure the SPIRE Servers to find the trust bundles for other trust domains. The `federates_with` configuration option in `server.conf` is where you specify the endpoint of the other trust domain. The configuration of this section has some slight differences when using the different methods of authentication.
+After configuring federation endpoints, the next step to enable SPIFFE federation is to configure the SPIRE Servers to find the trust bundles for other trust domains. The `federates_with` configuration option in `server.conf` is where you specify the endpoint of the other trust domain. The configuration of this section has some slight differences when using the different methods of authentication, according with the requirements for each endpoint profile.
 
-## Configure Trust Bundle Location Using SPIFFE Authentication
+## Configure Trust Bundle Location Using SPIFFE Authentication (https_spiffe)
 
 As we saw previously, the SPIRE Server of the stock market service provider has its federation endpoint listening on port `8443` at any IP address. We will also assume that `spire-server-stock` is a DNS name that resolves to the stock market service's SPIRE Server IP address. (The Docker Compose demo here uses the hostname `spire-server-stock`, but in typical usage you would specify a FQDN.) Then, the broker's SPIRE Server must be configured with the following `federates_with` section:
 ```hcl
@@ -132,9 +132,9 @@ server {
             port = 8443
         }
         federates_with "stockmarket.example" {
-            bundle_endpoint {
-                address = "spire-server-stock"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-stock:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://stockmarket.example/spire/server"
             }
         }
     }
@@ -157,19 +157,19 @@ server {
             port = 8443
         }
         federates_with "broker.example" {
-            bundle_endpoint {
-                address = "spire-server-broker"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-broker:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://broker.example/spire/server"
             }
         }
     }
 }
 ```
-That is it. Specifying the `federation` section and `federates_with` subsection of `server.conf` is all that's needed configure SPIFFE federation. To finish enabling SPIFFE federation, we need to bootstrap the trust bundles and register the workloads using `spire-server` commands as described below.
+Note that the "https_spiffe" profile has been specified, indicating the expected SPIFFE ID of the bundle endpoint. Specifying the `federation` section and `federates_with` subsection of `server.conf` is all that's needed to configure SPIFFE federation. To finish enabling SPIFFE federation, we need to bootstrap the trust bundles and register the workloads using `spire-server` commands as described below.
 
-## Configure Trust Bundle Location Using Web PKI authentication
+## Configure Trust Bundle Location Using Web PKI authentication (https_web)
 
-As mentioned, in this alternate scenario we are assuming that only the broker's SPIRE Server will use Web PKI authentication for its federation endpoint, so the `federates_with` configuration for the broker server is the same as seen in the previous section. However, the SPIRE Server of the stock market service provider needs a different configuration:
+As mentioned, in this alternate scenario we are assuming that only the broker's SPIRE Server will use Web PKI authentication for its federation endpoint, so the `federates_with` configuration for the broker server is the same as seen in the previous section. However, the SPIRE Server of the stock market service provider needs a different configuration that specifies the "https_web" profile instead of "https_spiffe":
 
 ```hcl
 server {
@@ -185,18 +185,13 @@ server {
             port = 8443
         }
         federates_with "broker.example" {
-            bundle_endpoint {
-                address = "broker.example"
-                use_web_pki = true
-            }
+            bundle_endpoint_url = "https://spire-server-broker:8443"
+            bundle_endpoint_profile "https_web" {}
         }
     }
 }
 ```
-The differences are:
-- `port` was removed. This is because by default it is set to `443`, which is the port where the broker's federation bundle endpoint is listening.
-- `address` now is set to the broker's domain `broker.example`.
-- `use_web_pki` was added and set to `true`. This is mandatory when the bundle endpoint to which we want to federate is using Web PKI authentication.
+It can be noticed that the "https_web" profile does not require additional configuration settings. Endpoints are authenticated using the same public CA certificates installed in the operating system.
 
 # Bootstrap Federation
 
@@ -266,7 +261,7 @@ Similarly, once this registration entry is created, when the quotes service asks
 
 That is about it. Now all the pieces are in place to make federation work and demonstrate how the webapp is able to communicate with the quotes service despite having identities with different trust domains.
 
-# Federation Example Using SPIFFE Authentication with SPIRE 0.11.0
+# Federation Example Using SPIFFE Authentication with SPIRE 1.0.0
 
 This section explains how to use Docker Compose to try an example implementation of the SPIFFE auth scenario described in this tutorial.
 
@@ -341,7 +336,7 @@ You should see:
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-server/private/api.sock"
     trust_domain = "broker.example"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
@@ -359,11 +354,11 @@ server {
             port = 8443
         }
         federates_with "stockmarket.example" {
-            bundle_endpoint {
-                address = "spire-server-stock"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-stock:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://stockmarket.example/spire/server"
             }
-        }    
+        }
     }
 }
 
@@ -375,11 +370,11 @@ plugins {
         }
     }
 
-        NodeAttestor "x509pop" {
-                plugin_data {
-                        ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
-                }
-        }
+	NodeAttestor "x509pop" {
+		plugin_data {
+			ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
+		}
+	}
 
     NodeResolver "noop" {
         plugin_data {}
@@ -403,7 +398,7 @@ You should see:
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-server/private/api.sock"
     trust_domain = "stockmarket.example"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
@@ -421,11 +416,11 @@ server {
             port = 8443
         }
         federates_with "broker.example" {
-            bundle_endpoint {
-                address = "spire-server-broker"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-broker:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://broker.example/spire/server"
             }
-        }    
+        }
     }
 }
 
@@ -437,11 +432,11 @@ plugins {
         }
     }
 
-        NodeAttestor "x509pop" {
-                plugin_data {
-                        ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
-                }
-        }
+	NodeAttestor "x509pop" {
+		plugin_data {
+			ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
+		}
+	}
 
     NodeResolver "noop" {
         plugin_data {}
@@ -498,4 +493,3 @@ FederatesWith : spiffe://broker.example
 ```
 $ docker-compose down
 ```
-

--- a/docker-compose/federation/docker/broker-webapp/Dockerfile
+++ b/docker-compose/federation/docker/broker-webapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-agent:0.11.0
+FROM gcr.io/spiffe-io/spire-agent:1.0.0
 
 COPY conf/agent.conf /opt/spire/conf/agent/agent.conf
 COPY conf/agent.key.pem /opt/spire/conf/agent/agent.key.pem

--- a/docker-compose/federation/docker/spire-server-broker.example/Dockerfile
+++ b/docker-compose/federation/docker/spire-server-broker.example/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-server:0.11.0
+FROM gcr.io/spiffe-io/spire-server:1.0.0
 
 # Override spire configurations
 COPY conf/server.conf /opt/spire/conf/server/server.conf

--- a/docker-compose/federation/docker/spire-server-broker.example/conf/server.conf
+++ b/docker-compose/federation/docker/spire-server-broker.example/conf/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-server/private/api.sock"
     trust_domain = "broker.example"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
@@ -19,11 +19,11 @@ server {
             port = 8443
         }
         federates_with "stockmarket.example" {
-            bundle_endpoint {
-                address = "spire-server-stock"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-stock:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://stockmarket.example/spire/server"
             }
-        }    
+        }
     }
 }
 

--- a/docker-compose/federation/docker/spire-server-stockmarket.example/Dockerfile
+++ b/docker-compose/federation/docker/spire-server-stockmarket.example/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-server:0.11.0
+FROM gcr.io/spiffe-io/spire-server:1.0.0
 
 # Override spire configurations
 COPY conf/server.conf /opt/spire/conf/server/server.conf

--- a/docker-compose/federation/docker/spire-server-stockmarket.example/conf/server.conf
+++ b/docker-compose/federation/docker/spire-server-stockmarket.example/conf/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-server/private/api.sock"
     trust_domain = "stockmarket.example"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"
@@ -19,11 +19,11 @@ server {
             port = 8443
         }
         federates_with "broker.example" {
-            bundle_endpoint {
-                address = "spire-server-broker"
-                port = 8443
+            bundle_endpoint_url = "https://spire-server-broker:8443"
+            bundle_endpoint_profile "https_spiffe" {
+                endpoint_spiffe_id = "spiffe://broker.example/spire/server"
             }
-        }    
+        }
     }
 }
 

--- a/docker-compose/federation/docker/stock-quotes-service/Dockerfile
+++ b/docker-compose/federation/docker/stock-quotes-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/spiffe-io/spire-agent:0.11.0 as spire
+FROM gcr.io/spiffe-io/spire-agent:1.0.0 as spire
 
 COPY conf/agent.conf /opt/spire/conf/agent/agent.conf
 COPY conf/agent.key.pem /opt/spire/conf/agent/agent.key.pem

--- a/docker-compose/metrics/docker-compose.yaml
+++ b/docker-compose/metrics/docker-compose.yaml
@@ -18,13 +18,13 @@ services:
     ports:
       - "9090:9090"
   spire-server:
-    image: gcr.io/spiffe-io/spire-server:0.11.0
+    image: gcr.io/spiffe-io/spire-server:1.0.0
     hostname: spire-server
     volumes:
         - ./spire/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   spire-agent:
-    image: gcr.io/spiffe-io/spire-agent:0.11.0
+    image: gcr.io/spiffe-io/spire-agent:1.0.0
     depends_on: ["spire-server"]
     hostname: spire-agent
     volumes:

--- a/docker-compose/metrics/spire/server/server.conf
+++ b/docker-compose/metrics/spire/server/server.conf
@@ -1,7 +1,7 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    registration_uds_path = "/tmp/spire-registration.sock"
+    socket_path = "/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"

--- a/docker-compose/nested-spire/README.md
+++ b/docker-compose/nested-spire/README.md
@@ -48,7 +48,7 @@ We define all the services for the tutorial in the [docker-compose.yaml](docker-
    services:
      # Root
      root-server:
-       image: gcr.io/spiffe-io/spire-server:0.11.0
+       image: gcr.io/spiffe-io/spire-server:1.0.0
        hostname: root-server
        volumes:
          - ./root/server:/opt/spire/conf/server
@@ -56,7 +56,7 @@ We define all the services for the tutorial in the [docker-compose.yaml](docker-
      root-agent:
        # Share the host pid namespace so this agent can attest the nested servers
        pid: "host"
-       image: gcr.io/spiffe-io/spire-agent:0.11.0
+       image: gcr.io/spiffe-io/spire-agent:1.0.0
        depends_on: ["root-server"]
        hostname: root-agent
        volumes:
@@ -91,7 +91,7 @@ The Docker Compose definition for the `nestedA-server` service in the [docker-co
    nestedA-server:
      # Share the host pid namespace so this server can be attested by the root agent
      pid: "host"
-     image: gcr.io/spiffe-io/spire-server:0.11.0
+     image: gcr.io/spiffe-io/spire-server:1.0.0
      hostname: nestedA-server
      labels:
        # label to attest nestedA-server against root-agent

--- a/docker-compose/nested-spire/docker-compose.yaml
+++ b/docker-compose/nested-spire/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # Root
   root-server:
-    image: gcr.io/spiffe-io/spire-server:0.11.0
+    image: gcr.io/spiffe-io/spire-server:1.0.0
     hostname: root-server
     volumes:
       - ./root/server:/opt/spire/conf/server
@@ -10,7 +10,7 @@ services:
   root-agent:
     # Share the host pid namespace so this agent can attest the nested servers
     pid: "host"
-    image: gcr.io/spiffe-io/spire-agent:0.11.0
+    image: gcr.io/spiffe-io/spire-agent:1.0.0
     depends_on: ["root-server"]
     hostname: root-agent
     volumes:
@@ -23,7 +23,7 @@ services:
   nestedA-server:
     # Share the host pid namespace so this server can be attested by the root agent
     pid: "host"
-    image: gcr.io/spiffe-io/spire-server:0.11.0
+    image: gcr.io/spiffe-io/spire-server:1.0.0
     hostname: nestedA-server
     labels:
       # label to attest server against root-agent
@@ -35,7 +35,7 @@ services:
       - ./nestedA/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedA-agent:
-    image: gcr.io/spiffe-io/spire-agent:0.11.0
+    image: gcr.io/spiffe-io/spire-agent:1.0.0
     hostname: nestedA-agent
     depends_on: ["nestedA-server"]
     volumes:
@@ -45,7 +45,7 @@ services:
   nestedB-server:
     # Share the host pid namespace so this server can be attested by the root agent
     pid: "host"
-    image: gcr.io/spiffe-io/spire-server:0.11.0
+    image: gcr.io/spiffe-io/spire-server:1.0.0
     hostname: nestedB-server
     depends_on: ["root-server","root-agent"]
     labels:
@@ -57,7 +57,7 @@ services:
       - ./nestedB/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedB-agent:
-    image: gcr.io/spiffe-io/spire-agent:0.11.0
+    image: gcr.io/spiffe-io/spire-agent:1.0.0
     hostname: nestedB-agent
     depends_on: ["nestedB-server"]
     volumes:

--- a/docker-compose/nested-spire/nestedA/server/server.conf
+++ b/docker-compose/nested-spire/nestedA/server/server.conf
@@ -1,7 +1,7 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
+	socket_path = "/tmp/spire-server/private/api.sock"
 	trust_domain = "example.org"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/docker-compose/nested-spire/nestedB/server/server.conf
+++ b/docker-compose/nested-spire/nestedB/server/server.conf
@@ -1,7 +1,7 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
+	socket_path = "/tmp/spire-server/private/api.sock"
 	trust_domain = "example.org"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/docker-compose/nested-spire/root/server/server.conf
+++ b/docker-compose/nested-spire/root/server/server.conf
@@ -1,7 +1,7 @@
 server {
 	bind_address = "0.0.0.0"
 	bind_port = "8081"
-	registration_uds_path = "/tmp/spire-registration.sock"
+	socket_path = "/tmp/spire-server/private/api.sock"
 	trust_domain = "example.org"
 	data_dir = "/opt/spire/data/server"
 	log_level = "DEBUG"

--- a/k8s/oidc-aws/agent-daemonset.yaml
+++ b/k8s/oidc-aws/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.12.0
+          image: gcr.io/spiffe-io/spire-agent:1.0.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -8,7 +8,7 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      registration_uds_path = "/run/spire/sockets/registration.sock"
+      socket_path = "/tmp/spire-server/private/api.sock"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.12.0
+          image: gcr.io/spiffe-io/spire-server:1.0.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -52,7 +52,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.12.0
+          image: gcr.io/spiffe-io/oidc-discovery-provider:1.0.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/oidc-vault/k8s/server-configmap.yaml
+++ b/k8s/oidc-vault/k8s/server-configmap.yaml
@@ -8,7 +8,7 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      registration_uds_path = "/run/spire/sockets/registration.sock"
+      socket_path = "/tmp/spire-server/private/api.sock"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -21,7 +21,7 @@ spec:
       shareProcessNamespace: true
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.12.0
+          image: gcr.io/spiffe-io/spire-server:1.0.0
           args:
             - -config
             - /run/spire/config/server.conf
@@ -52,7 +52,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 5
         - name: spire-oidc
-          image: gcr.io/spiffe-io/oidc-discovery-provider:0.12.0
+          image: gcr.io/spiffe-io/oidc-discovery-provider:1.0.0
           args:
           - -config
           - /run/spire/oidc/config/oidc-discovery-provider.conf

--- a/k8s/quickstart/agent-daemonset.yaml
+++ b/k8s/quickstart/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-t", "30", "spire-server:8081"]
       containers:
         - name: spire-agent
-          image: gcr.io/spiffe-io/spire-agent:0.12.0
+          image: gcr.io/spiffe-io/spire-agent:1.0.0
           args: ["-config", "/run/spire/config/agent.conf"]
           volumeMounts:
             - name: spire-config

--- a/k8s/quickstart/client-deployment.yaml
+++ b/k8s/quickstart/client-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet
       containers:
         - name: client
-          image: gcr.io/spiffe-io/spire-agent:0.12.0
+          image: gcr.io/spiffe-io/spire-agent:1.0.0
           command: ["sleep"]
           args: ["1000000000"]
           volumeMounts:

--- a/k8s/quickstart/server-configmap.yaml
+++ b/k8s/quickstart/server-configmap.yaml
@@ -8,7 +8,7 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      registration_uds_path = "/tmp/spire-registration.sock"
+      socket_path = "/tmp/spire-server/private/api.sock"
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"

--- a/k8s/quickstart/server-statefulset.yaml
+++ b/k8s/quickstart/server-statefulset.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: spire-server
       containers:
         - name: spire-server
-          image: gcr.io/spiffe-io/spire-server:0.12.0
+          image: gcr.io/spiffe-io/spire-server:1.0.0
           args:
             - -config
             - /run/spire/config/server.conf


### PR DESCRIPTION
Update tutorials to use SPIRE 1.0.0.
The documentation for the Federation tutorial was updated to reflect the changes introduced in 1.0.0.

Fixes #64.