### PR TITLE
Update service account allow list configurable

### DIFF
--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -51,7 +51,7 @@ data:
             # TODO: Change this to your cluster name
             "demo-cluster" = {
               use_token_review_api_validation = true
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }

--- a/k8s/oidc-vault/k8s/server-configmap.yaml
+++ b/k8s/oidc-vault/k8s/server-configmap.yaml
@@ -50,7 +50,7 @@ data:
             # TODO: Change this to your cluster name
             "MY_CLUSTER_NAME" = {
               use_token_review_api_validation = true
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }

--- a/k8s/quickstart/server-configmap.yaml
+++ b/k8s/quickstart/server-configmap.yaml
@@ -37,7 +37,7 @@ data:
             # NOTE: Change this to your cluster name
             "demo-cluster" = {
               use_token_review_api_validation = true
-              service_account_whitelist = ["spire:spire-agent"]
+              service_account_allow_list = ["spire:spire-agent"]
             }
           }
         }


### PR DESCRIPTION
The `k8s_sat` and `k8s_psat` NodeAttestor configurable
`service_account_whitelist` has been removed in the 1.1.0 release
after having been deprecated in favour of `service_account_allow_list`
in 1.0.0.

See:
- https://github.com/spiffe/spire/pull/2253
- https://github.com/spiffe/spire/pull/2543