### PR TITLE
Remove noop NodeResolver

### DIFF
--- a/docker-compose/federation/README.md
+++ b/docker-compose/federation/README.md
@@ -376,10 +376,6 @@ plugins {
 		}
 	}
 
-    NodeResolver "noop" {
-        plugin_data {}
-    }
-
     KeyManager "memory" {
         plugin_data = {}
     }
@@ -437,10 +433,6 @@ plugins {
 			ca_bundle_path = "/opt/spire/conf/server/agent-cacert.pem"
 		}
 	}
-
-    NodeResolver "noop" {
-        plugin_data {}
-    }
 
     KeyManager "memory" {
         plugin_data = {}

--- a/docker-compose/federation/docker/spire-server-broker.example/conf/server.conf
+++ b/docker-compose/federation/docker/spire-server-broker.example/conf/server.conf
@@ -41,10 +41,6 @@ plugins {
 		}
 	}
 
-    NodeResolver "noop" {
-        plugin_data {}
-    }
-
     KeyManager "memory" {
         plugin_data = {}
     }

--- a/docker-compose/federation/docker/spire-server-stockmarket.example/conf/server.conf
+++ b/docker-compose/federation/docker/spire-server-stockmarket.example/conf/server.conf
@@ -41,10 +41,6 @@ plugins {
 		}
 	}
 
-    NodeResolver "noop" {
-        plugin_data {}
-    }
-
     KeyManager "memory" {
         plugin_data = {}
     }

--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -57,10 +57,6 @@ data:
         }
       }
 
-      NodeResolver "noop" {
-        plugin_data {}
-      }
-
       KeyManager "disk" {
         plugin_data {
           keys_path = "/run/spire/data/keys.json"

--- a/k8s/oidc-vault/k8s/server-configmap.yaml
+++ b/k8s/oidc-vault/k8s/server-configmap.yaml
@@ -56,10 +56,6 @@ data:
         }
       }
 
-      NodeResolver "noop" {
-        plugin_data {}
-      }
-
       KeyManager "disk" {
         plugin_data {
           keys_path = "/run/spire/data/keys.json"

--- a/k8s/quickstart/server-configmap.yaml
+++ b/k8s/quickstart/server-configmap.yaml
@@ -43,10 +43,6 @@ data:
         }
       }
 
-      NodeResolver "noop" {
-        plugin_data {}
-      }
-
       KeyManager "disk" {
         plugin_data {
           keys_path = "/run/spire/data/keys.json"


### PR DESCRIPTION
The noop NodeResolver has been removed in 1.0.0.

See:
- https://github.com/spiffe/spire/pull/2189

Signed-off-by: Wolodja Wentland <wolodja.wentland@control-plane.io>