### PR TITLE
Remove socket_path form server config

### DIFF
--- a/docker-compose/metrics/spire/server/server.conf
+++ b/docker-compose/metrics/spire/server/server.conf
@@ -1,7 +1,6 @@
 server {
     bind_address = "0.0.0.0"
     bind_port = "8081"
-    socket_path = "/tmp/spire-registration.sock"
     trust_domain = "example.org"
     data_dir = "/opt/spire/data/server"
     log_level = "DEBUG"


### PR DESCRIPTION
socket_path points to a non standard location. This breaks scripts/set-env.sh line 24 where the config option is not given.
after removing socket_path the script runs fine