### PR TITLE
Remove "ps"-based OIDC Discovery Provider readiness probes

### DIFF
--- a/k8s/oidc-aws/oidc-dp-configmap.yaml
+++ b/k8s/oidc-aws/oidc-dp-configmap.yaml
@@ -7,7 +7,7 @@ data:
   oidc-discovery-provider.conf: |
     log_level = "INFO"
     # TODO: Replace MY_DISCOVERY_DOMAIN with the FQDN of the Discovery Provider that you will configure in DNS
-    domain = "MY_DISCOVERY_DOMAIN"
+    domains = ["MY_DISCOVERY_DOMAIN"]
     acme {
         directory_url = "https://acme-v02.api.letsencrypt.org/directory"
         cache_dir = "/run/spire"
@@ -18,3 +18,4 @@ data:
     server_api {
       address = "unix:///tmp/spire-server/private/api.sock"
     }
+    health_checks {}

--- a/k8s/oidc-aws/server-configmap.yaml
+++ b/k8s/oidc-aws/server-configmap.yaml
@@ -12,15 +12,11 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      experimental {
-        // Turns on the bundle endpoint (required, true)
-        bundle_endpoint_enabled = true
-
-        // The address to listen on (optional, defaults to 0.0.0.0)
-        // bundle_endpoint_address = "0.0.0.0"
-
-        // The port to listen on (optional, defaults to 443)
-        bundle_endpoint_port = 8443
+      federation {
+        bundle_endpoint {
+          address = "0.0.0.0"
+          port = 8443
+        }
       }
       #AWS requires the use of RSA.  EC cryptography is not supported
       ca_key_type = "rsa-2048"

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -69,11 +69,6 @@ spec:
           - name: spire-data
             mountPath: /run/spire/data
             readOnly: false
-          readinessProbe:
-            exec:
-              command: ["/bin/ps", "aux", " ||", "grep", "oidc-discovery-provider -config /run/spire/oidc/config/oidc-discovery-provider.conf"]
-            initialDelaySeconds: 5
-            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/k8s/oidc-aws/server-statefulset.yaml
+++ b/k8s/oidc-aws/server-statefulset.yaml
@@ -69,6 +69,14 @@ spec:
           - name: spire-data
             mountPath: /run/spire/data
             readOnly: false
+          readinessProbe:
+            httpGet:
+              path: /keys # TODO: Change this to /ready when using 1.5.2+
+              port: 8008
+            failureThreshold: 5
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
       volumes:
         - name: spire-config
           configMap:

--- a/k8s/oidc-vault/k8s/oidc-dp-configmap.yaml
+++ b/k8s/oidc-vault/k8s/oidc-dp-configmap.yaml
@@ -18,3 +18,4 @@ data:
     server_api {
       address = "unix:///tmp/spire-server/private/api.sock"
     }
+    health_checks {}

--- a/k8s/oidc-vault/k8s/server-configmap.yaml
+++ b/k8s/oidc-vault/k8s/server-configmap.yaml
@@ -12,15 +12,11 @@ data:
       trust_domain = "example.org"
       data_dir = "/run/spire/data"
       log_level = "DEBUG"
-      experimental {
-        // Turns on the bundle endpoint (required, true)
-        bundle_endpoint_enabled = true
-
-        // The address to listen on (optional, defaults to 0.0.0.0)
-        // bundle_endpoint_address = "0.0.0.0"
-
-        // The port to listen on (optional, defaults to 443)
-        bundle_endpoint_port = 8443
+      federation {
+        bundle_endpoint {
+          address = "0.0.0.0"
+          port = 8443
+        }
       }
       ca_key_type = "rsa-2048"
 

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -69,11 +69,6 @@ spec:
           - name: spire-data
             mountPath: /run/spire/data
             readOnly: false
-          readinessProbe:
-            exec:
-              command: ["/bin/ps", "aux", " ||", "grep", "oidc-discovery-provider -config /run/spire/oidc/config/oidc-discovery-provider.conf"]
-            initialDelaySeconds: 5
-            periodSeconds: 5
       volumes:
         - name: spire-config
           configMap:

--- a/k8s/oidc-vault/k8s/server-statefulset.yaml
+++ b/k8s/oidc-vault/k8s/server-statefulset.yaml
@@ -69,6 +69,14 @@ spec:
           - name: spire-data
             mountPath: /run/spire/data
             readOnly: false
+          readinessProbe:
+            httpGet:
+              path: /keys # TODO: Change this to /ready when using 1.5.2+
+              port: 8008
+            failureThreshold: 5
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
       volumes:
         - name: spire-config
           configMap:


### PR DESCRIPTION
We are migrating away from the alpine images towards the scratch images being the default. In a scratch image, we don't have the `ps` binary.

There is a bug in the OIDC Discovery Provider that prevents the HTTP liveness/readiness endpoint from being available outside the container (see spiffe/spire#3629), so update the readiness probes to use `/keys` for now. Turn on the health check endpoint to the OIDC Discovery Provider so that probes can be added later on once the issue is resolved.

Also update some old configs that are no longer correct to get the examples to run properly with newer versions of SPIRE/OIDC Discovery Endpoint.