### PR TITLE
Update to latest GitHub actions versions

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -15,9 +15,9 @@ jobs:
     timeout-minutes: 30
     steps: 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: install minikube


### PR DESCRIPTION
The v2 actions use Node.js 12, and are now deprecated. Use the latest versions of each action to avoid this message on CI:

"Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-go@v2"