### PR TITLE
Update spire-agent daemonset to use node IP from downward API (#4147).

### DIFF
--- a/k8s/quickstart/agent-configmap.yaml
+++ b/k8s/quickstart/agent-configmap.yaml
@@ -34,6 +34,7 @@ data:
           # Minikube does not have a cert in the cluster CA bundle that
           # can authenticate the kubelet cert, so skip validation.
           skip_kubelet_verification = true
+          node_name_env = "MY_NODE_NAME"
         }
       }
 

--- a/k8s/quickstart/agent-daemonset.yaml
+++ b/k8s/quickstart/agent-daemonset.yaml
@@ -26,11 +26,6 @@ spec:
           # from https://github.com/lqhl/wait-for-it
           image: cgr.dev/chainguard/wait-for-it
           args: ["-t", "30", "spire-server:8081"]
-          env:
-          - name: MY_NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: status.podIP
       containers:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.5.1

--- a/k8s/quickstart/agent-daemonset.yaml
+++ b/k8s/quickstart/agent-daemonset.yaml
@@ -26,10 +26,20 @@ spec:
           # from https://github.com/lqhl/wait-for-it
           image: cgr.dev/chainguard/wait-for-it
           args: ["-t", "30", "spire-server:8081"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
       containers:
         - name: spire-agent
           image: ghcr.io/spiffe/spire-agent:1.5.1
           args: ["-config", "/run/spire/config/agent.conf"]
+          env:
+          - name: MY_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
           volumeMounts:
             - name: spire-config
               mountPath: /run/spire/config


### PR DESCRIPTION
Fixes issue [#4147](https://github.com/spiffe/spire/issues/4147) in the spire repo. The spire-agent daemonsets in the examples defaults to using localhost to reach the kubelet API. This fails in some cases and this PR fixes the issue by retrieving the node IP using the downward API and passing it to the spire-agent daemonset configuration.

The issue is raised in the spire repo but fixes span across spire-examples, spire-tutorials and spire-controller-manager repos under the SPIFFE org.