### PR TITLE
Fix envoy-jwt-auth-helper

### DIFF
--- a/k8s/envoy-jwt-auth-helper/Dockerfile
+++ b/k8s/envoy-jwt-auth-helper/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:latest as build-stage
+FROM golang:bookworm as build-stage
 
 WORKDIR /app
 COPY . .
 RUN go mod download
 RUN go build
 
-FROM debian:buster-slim as production-stage
+FROM debian:bookworm-slim as production-stage
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt full-upgrade -y && \
 apt install -y dumb-init iputils-ping curl procps
 


### PR DESCRIPTION
While running through the envoy JWT tutorial I hit the following error
in the envoy-jwt-auth-helper:

  /opt/helper/envoy-jwt-auth-helper: /lib/x86_64-linux-gnu/libc.so.6:
  version GLIBC_2.34' not found (required by /opt/helper/envoy-jwt-auth-helper)

The auth helper image builds with golang:latest (currently based on
debian bookworm), then copies to a debian buster.

This change fixes the issue by syncing the build and production stage
images.

Fixes: #136
