### PR TITLE
Fix the nested-spire example in macOS

### DIFF
--- a/docker-compose/nested-spire/docker-compose.yaml
+++ b/docker-compose/nested-spire/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 services:
   # Root
   root-server:
-    image: ghcr.io/spiffe/spire-server:1.5.1
+    image: ghcr.io/spiffe/spire-server:1.11.2
     hostname: root-server
     volumes:
       - ./root/server:/opt/spire/conf/server
@@ -10,7 +10,7 @@ services:
   root-agent:
     # Share the host pid namespace so this agent can attest the nested servers
     pid: "host"
-    image: ghcr.io/spiffe/spire-agent:1.5.1
+    image: ghcr.io/spiffe/spire-agent:1.11.2
     depends_on: ["root-server"]
     hostname: root-agent
     volumes:
@@ -23,7 +23,7 @@ services:
   nestedA-server:
     # Share the host pid namespace so this server can be attested by the root agent
     pid: "host"
-    image: ghcr.io/spiffe/spire-server:1.5.1
+    image: ghcr.io/spiffe/spire-server:1.11.2
     hostname: nestedA-server
     labels:
       # label to attest server against root-agent
@@ -35,7 +35,7 @@ services:
       - ./nestedA/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedA-agent:
-    image: ghcr.io/spiffe/spire-agent:1.5.1
+    image: ghcr.io/spiffe/spire-agent:1.11.2
     hostname: nestedA-agent
     depends_on: ["nestedA-server"]
     volumes:
@@ -45,7 +45,7 @@ services:
   nestedB-server:
     # Share the host pid namespace so this server can be attested by the root agent
     pid: "host"
-    image: ghcr.io/spiffe/spire-server:1.5.1
+    image: ghcr.io/spiffe/spire-server:1.11.2
     hostname: nestedB-server
     depends_on: ["root-server","root-agent"]
     labels:
@@ -57,7 +57,7 @@ services:
       - ./nestedB/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedB-agent:
-    image: ghcr.io/spiffe/spire-agent:1.5.1
+    image: ghcr.io/spiffe/spire-agent:1.11.2
     hostname: nestedB-agent
     depends_on: ["nestedB-server"]
     volumes:

--- a/docker-compose/nested-spire/docker-compose.yaml
+++ b/docker-compose/nested-spire/docker-compose.yaml
@@ -15,9 +15,9 @@ services:
     hostname: root-agent
     volumes:
       # Share root-agent socket to be accessed by nested servers
-      - ./sharedRootSocket:/opt/spire/sockets
+      - spire-sockets:/opt/spire/sockets
       - ./root/agent:/opt/spire/conf/agent
-      - /var/run/:/var/run/
+      - /var/run/docker.sock:/var/run/docker.sock
     command: ["-config", "/opt/spire/conf/agent/agent.conf"]
   # NestedA
   nestedA-server:
@@ -31,7 +31,7 @@ services:
     depends_on: ["root-server","root-agent"]
     volumes:
       # Add root-agent socket
-      - ./sharedRootSocket:/opt/spire/sockets
+      - spire-sockets:/opt/spire/sockets
       - ./nestedA/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedA-agent:
@@ -40,7 +40,7 @@ services:
     depends_on: ["nestedA-server"]
     volumes:
       - ./nestedA/agent:/opt/spire/conf/agent
-      - /var/run/:/var/run/
+      - /var/run/docker.sock:/var/run/docker.sock
     command: ["-config", "/opt/spire/conf/agent/agent.conf"]
   nestedB-server:
     # Share the host pid namespace so this server can be attested by the root agent
@@ -53,7 +53,7 @@ services:
       - org.example.name=nestedB-server
     volumes:
       # Add root-agent socket
-      - ./sharedRootSocket:/opt/spire/sockets
+      - spire-sockets:/opt/spire/sockets
       - ./nestedB/server:/opt/spire/conf/server
     command: ["-config", "/opt/spire/conf/server/server.conf"]
   nestedB-agent:
@@ -62,5 +62,15 @@ services:
     depends_on: ["nestedB-server"]
     volumes:
       - ./nestedB/agent:/opt/spire/conf/agent
-      - /var/run/:/var/run/
+      - /var/run/docker.sock:/var/run/docker.sock
     command: ["-config", "/opt/spire/conf/agent/agent.conf"]
+
+volumes:
+  # Allows macs to have functional domain sockets between spire agents and
+  # servers by avoiding a volume mount to the host filesystem and instead
+  # creating a tmpfs volume to be used as a socket directory.
+  spire-sockets:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs

--- a/docker-compose/nested-spire/scripts/set-env.sh
+++ b/docker-compose/nested-spire/scripts/set-env.sh
@@ -31,6 +31,20 @@ fingerprint() {
 	openssl x509 -in "$1" -outform DER | openssl sha1 -r | awk '{print $1}'
 }
 
+wait-for-server() {
+  for ((i=1;i<=30;i++)); do
+    if ! docker-compose -f "${PARENT_DIR}"/docker-compose.yaml exec -T $1 /opt/spire/bin/spire-server healthcheck; then
+        log "Waiting for $1 to start..."
+        sleep 1
+    else
+      log "${green}$1 is up and running.${norm}"
+      return 0
+    fi
+  done
+  log "${red}$1 did not start.${norm}"
+  return 1
+}
+
 check-entry-is-propagated() {
   # Check at most 30 times that the agent has successfully synced down the workload entry.
   # Wait one second between checks.
@@ -68,6 +82,9 @@ setup "${PARENT_DIR}"/root/server "${PARENT_DIR}"/root/agent
 log "Start root server"
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml up -d root-server
 
+wait-for-server root-server
+docker-compose -f "${PARENT_DIR}"/docker-compose.yaml exec -T root-server /opt/spire/bin/spire-server bundle show > "${PARENT_DIR}"/root/agent/bootstrap.crt
+
 log "bootstrapping root-agent."
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml exec -T root-server /opt/spire/bin/spire-server bundle show > "${PARENT_DIR}"/root/agent/bootstrap.crt
 
@@ -103,6 +120,7 @@ setup "${PARENT_DIR}"/nestedA/server "${PARENT_DIR}"/nestedA/agent
 log "Starting nestedA-server.."
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml up -d nestedA-server
 
+wait-for-server nestedA-server
 log "bootstrapping nestedA agent..."
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml exec -T nestedA-server /opt/spire/bin/spire-server bundle show > "${PARENT_DIR}"/nestedA/agent/bootstrap.crt
 
@@ -117,6 +135,7 @@ setup "${PARENT_DIR}"/nestedB/server "${PARENT_DIR}"/nestedB/agent
 log "Starting nestedB-server.."
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml up -d nestedB-server
 
+wait-for-server nestedB-server
 log "bootstrapping nestedB agent..."
 docker-compose -f "${PARENT_DIR}"/docker-compose.yaml exec -T nestedB-server /opt/spire/bin/spire-server bundle show > "${PARENT_DIR}"/nestedB/agent/bootstrap.crt
 

--- a/docker-compose/nested-spire/scripts/set-env.sh
+++ b/docker-compose/nested-spire/scripts/set-env.sh
@@ -71,10 +71,6 @@ fi
 sed -i.bak "s#\#container_id_cgroup_matchers#container_id_cgroup_matchers#" "${PARENT_DIR}"/root/agent/agent.conf
 sed -i.bak "s#CGROUP_MATCHERS#$CGROUP_MATCHERS#" "${PARENT_DIR}"/root/agent/agent.conf
 
-# create a shared folder for root agent socket to be accessed by nestedA and nestedB servers
-mkdir -p "${PARENT_DIR}"/sharedRootSocket
-
-
 # Starts root SPIRE deployment
 log "Generate certificates for the root SPIRE deployment"
 setup "${PARENT_DIR}"/root/server "${PARENT_DIR}"/root/agent


### PR DESCRIPTION
Various small changes to make the nested-spire example work on a macOS host running Docker for Mac.

---
On my system, the first run of scripts/set-env.sh yields:

```
2025-03-13T02:46:39Z] bootstrapping root-agent.
Error: connection error: desc = "transport: error while dialing: dial unix
/tmp/spire-server/private/api.sock: connect: no such file or directory"
```

The naive thing to do is to merely re-run the script.

If you re-run set-env.sh after the above failure, new certs are generated but
the server appears to continue running and using the old ca. So lets
just make it work the first time by waiting for the server.

The other issues relate to Docker for Mac and it's hackish socket
handling. The /var/run/docker.sock is apparently special cased somehow
so we specify that single file in the volume mounts rather than the entire
/var/run folder.

---

The other error I saw had to do with sharing that `sharedSocket` folder:

```
 "Agent crashed" error="unable to change UDS permissions: chmod /opt/spire/sockets/workload_api.sock: invalid argument"
```

This originates here https://github.com/spiffe/spire/blob/v1.5.1/pkg/agent/endpoints/endpoints_posix.go#L32

Again, docker for mac "breaks" sockets created in this shared
volume when it's on the host filesystem because in practice it's some
rube-goldberg contraption with a lightweight VM under the hood.

So we just create a container-scoped volume instead, and bypass the
macOS host filesystem entirely. This might make it a bit funky to
interact with spire binaries running on our host - perhaps, but we could
always just add some bastion container to the docker-compose.yml file if
we want some tooling container for experimentation.
