### PR TITLE
k8s: add fsGroup to server-statefulset

### DIFF
--- a/k8s/quickstart/server-statefulset.yaml
+++ b/k8s/quickstart/server-statefulset.yaml
@@ -18,6 +18,8 @@ spec:
         app: spire-server
     spec:
       serviceAccountName: spire-server
+      securityContext:
+        fsGroup: 1000
       containers:
         - name: spire-server
           image: ghcr.io/spiffe/spire-server:1.11.2


### PR DESCRIPTION
This fixes https://github.com/spiffe/spire-tutorials/issues/142