### PR TITLE
k8s/quickstart: specify default namespace for client deployment

### DIFF
--- a/k8s/quickstart/client-deployment.yaml
+++ b/k8s/quickstart/client-deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: client
+  namespace: default
   labels:
     app: client
 spec:


### PR DESCRIPTION
The registration entry for the workload specifies a selector of `k8s:ns:default`, which means the workload should be running in the default namespace. If the namespace isn't specified in client-deployment.yaml, the workload will deploy to whichever namespace your context is currently set to, which can cause issue spiffe/spire-tutorials#123.

Fixes #123.